### PR TITLE
Fix graph attributes: print inside a "graph" block

### DIFF
--- a/dot.go
+++ b/dot.go
@@ -333,7 +333,7 @@ func (g *Graph) GetSubgraphs() (result []*SubGraph) {
 }
 
 func (g Graph) String() string {
-	parts := make([]string, 0)
+	var parts []string
 	if g.strict {
 		parts = append(parts, "strict ")
 	}
@@ -343,13 +343,16 @@ func (g Graph) String() string {
 		parts = append(parts, fmt.Sprintf("%s %s {\n", g.graphType, QuoteIfNecessary(g.name)))
 	}
 
-	attrs := make([]string, 0)
-	for _, key := range sortedKeys(g.attributes) {
-		attrs = append(attrs, key+"="+QuoteIfNecessary(g.attributes[key]))
-	}
-	if len(attrs) > 0 {
-		parts = append(parts, strings.Join(attrs, ";\n"))
-		parts = append(parts, ";\n")
+	if len(g.attributes) > 0 {
+		attrs := make([]string, 0, len(g.attributes))
+		for _, key := range sortedKeys(g.attributes) {
+			attrs = append(attrs, "  "+key+"="+QuoteIfNecessary(g.attributes[key]))
+		}
+		if len(attrs) > 0 {
+			parts = append(parts, "graph [\n")
+			parts = append(parts, strings.Join(attrs, ";\n"))
+			parts = append(parts, ";\n];\n")
+		}
 	}
 
 	objectList := make(graphObjects, 0)

--- a/dot_test.go
+++ b/dot_test.go
@@ -111,7 +111,9 @@ subgraph SG {
 
 func TestEdgeAddition(t *testing.T) {
 	simple_graph := `digraph G {
-label="this is a graph";
+graph [
+  label="this is a graph";
+];
 a -> b
 }
 `

--- a/example_test.go
+++ b/example_test.go
@@ -2,6 +2,7 @@ package dot_test
 
 import (
 	"fmt"
+
 	"github.com/tmc/dot"
 )
 
@@ -22,7 +23,9 @@ func ExampleNewGraph() {
 	fmt.Println(g)
 	// Output:
 	// digraph G {
-	// label="Example graph";
+	// graph [
+	//   label="Example graph";
+	// ];
 	// Node1 [color=sienna];
 	// Node2;
 	// Node1 -> Node2  [ dir=both ]


### PR DESCRIPTION
Attribute such as `rankdir` do not work if outside a `graph` block.

Fix: print graph attributes inside a `graph` block. 