### PR TITLE
Add support for HTML labels

### DIFF
--- a/dot.go
+++ b/dot.go
@@ -404,7 +404,12 @@ func (n Node) String() string {
 
 	attrs := make([]string, 0)
 	for _, key := range sortedKeys(n.attributes) {
-		attrs = append(attrs, key+"="+QuoteIfNecessary(n.attributes[key]))
+		value := n.attributes[key]
+		if key == "label" && len(value) > 4 && value[0] == '<' && value[len(value)-1] == '>' {
+			attrs = append(attrs, key+"="+value)
+		} else {
+			attrs = append(attrs, key+"="+QuoteIfNecessary(value))
+		}
 	}
 	if len(attrs) > 0 {
 		parts = append(parts, strings.Join(attrs, ", "))

--- a/dot_test.go
+++ b/dot_test.go
@@ -56,7 +56,12 @@ func TestCreateSimpleGraphWithNode(t *testing.T) {
 	g.AddNode(node)
 	node.Set("label", "value with spaces")
 
-	expected = "digraph Test {\nlegend [label=\"value with spaces\", shape=box];\n}\n"
+	node = dot.NewNode("html")
+	node.Set("shape", "plain")
+	node.Set("label", "<<B>bold</B>>")
+	g.AddNode(node)
+
+	expected = "digraph Test {\nlegend [label=\"value with spaces\", shape=box];\nhtml [label=<<B>bold</B>>, shape=plain];\n}\n"
 	if fmt.Sprint(g) != expected {
 		t.Errorf("'%s' != '%s'", fmt.Sprint(g), expected)
 	}


### PR DESCRIPTION
For [HTML labels](https://graphviz.gitlab.io/_pages/doc/info/shapes.html#html), the value must be quoted with <...> instead of "...".
This change specially handles the `label` attribute for nodes when the value starts with `<` and ends with `>`.