### PR TITLE
Allow `style` attribute on Graphs

### DIFF
--- a/graph.go
+++ b/graph.go
@@ -379,7 +379,7 @@ var graphAttributes = []string{
 	"outputorder", "overlap", "overlap_scaling", "pack", "packmode", "pad",
 	"page", "pagedir", "quadtree", "quantum", "rankdir", "ranksep", "ratio",
 	"remincross", "repulsiveforce", "resolution", "root", "rotate", "searchsize",
-	"sep", "showboxes", "size", "smoothing", "sortv", "splines", "start",
+	"sep", "showboxes", "size", "smoothing", "sortv", "splines", "start", "style",
 	"stylesheet", "target", "truecolor", "viewport", "voro_margin", "rank",
 }
 


### PR DESCRIPTION
As per [the graphviz documentation](https://graphviz.org/docs/attrs/style/)  `style` is a valid attribute on Graph & Clusters.

Fixes #9